### PR TITLE
UVC_FRAME_FORMAT_UYVY

### DIFF
--- a/libuvccamera/src/main/jni/UVCCamera/UVCPreview.cpp
+++ b/libuvccamera/src/main/jni/UVCCamera/UVCPreview.cpp
@@ -477,8 +477,8 @@ int UVCPreview::prepare_preview(uvc_stream_ctrl_t *ctrl) {
 
 	ENTER();
 	result = uvc_get_stream_ctrl_format_size_fps(mDeviceHandle, ctrl,
-		!requestMode ? UVC_FRAME_FORMAT_YUYV : UVC_FRAME_FORMAT_MJPEG,
-		requestWidth, requestHeight, requestMinFps, requestMaxFps
+		UVC_FRAME_FORMAT_UYVY,
+		requestWidth, requestHeight, 1, 9
 	);
 	if (LIKELY(!result)) {
 #if LOCAL_DEBUG


### PR DESCRIPTION
This patch allowed my PT1 to work on my android 7 phone. The fix is not a permanent solution, but allows the app to stream the UVC in the correct fusion palette.